### PR TITLE
Adding MacOS and Xcode cruft to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,47 @@
+*.DS_Store
+.AppleDouble
+.LSOverride
 
-.DS_Store
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+## Build generated
+build/
+DerivedData/
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint


### PR DESCRIPTION
PR adds standard Mac OS and Xcode files to gitignore. Will omit build and metadata files.